### PR TITLE
修改微信gif不能正常显示问题 fixed #21 #19 Thanks to @dengbotian

### DIFF
--- a/openshare/OpenShare+Weixin.m
+++ b/openshare/OpenShare+Weixin.m
@@ -70,7 +70,7 @@ static NSString *schema=@"Weixin";
             //gif
             dic[@"fileData"]= msg.file ? msg.file : [self dataWithImage:msg.image];
             dic[@"thumbData"]=msg.thumbnail ? [self dataWithImage:msg.thumbnail] : [self dataWithImage:msg.image scale:CGSizeMake(100, 100)];
-            dic[@"objectType"]=@"2";
+            dic[@"objectType"]=@"8";
         }
     }else if(msg.multimediaType==OSMultimediaTypeAudio){
         //music


### PR DESCRIPTION
//gif
dic[@"fileData"]= msg.file;
dic[@"thumbData"]=msg.thumbnail ? [self dataWithImage:msg.thumbnail] : [self dataWithImage:msg.image scale:CGSizeMake(100, 100)];
dic[@"objectType"]=@"8";
将微信gif分享中的objectType改为8 