### PR TITLE
FIX: open weibo URL crash

### DIFF
--- a/openshare/OpenShare+Weibo.m
+++ b/openshare/OpenShare+Weibo.m
@@ -103,7 +103,7 @@ static NSString *schema=@"Weibo";
         NSMutableDictionary *ret=[NSMutableDictionary dictionaryWithCapacity:items.count];
         for (NSDictionary *item in items) {
             for (NSString *k in item) {
-                ret[k]=[k isEqualToString:@"sdkVersion"]?item[k]:[NSKeyedUnarchiver unarchiveObjectWithData:item[k]];
+                ret[k]=[k isEqualToString:@"transferObject"]?[NSKeyedUnarchiver unarchiveObjectWithData:item[k]]:item[k];
             }
         }
         NSDictionary *transferObject=ret[@"transferObject"];


### PR DESCRIPTION
打开形如 wb402180334://
的URL会使items为
<__NSArrayM 0x14ff164d0>(
{
    "public.utf8-plain-text" = wb402180334;
}
)
调用unarchiveObjectWithData会
使app crash