### PR TITLE
项目实测：当调用OpenShare+Weibo.m中的shareToWeibo: 方法时，如果传入的参数msg为nil，项目会崩溃

### DIFF
--- a/openshare/OpenShare+Weibo.m
+++ b/openshare/OpenShare+Weibo.m
@@ -51,6 +51,8 @@ static NSString *schema=@"Weibo";
                           }
                   
                   };
+    }else {//当传入的msg为nil或不满足上面三种情况的时候应该直接返回,否则message会为nil,在下面的代码里使用message时会崩溃
+        return;
     }
     NSString *uuid=[[NSUUID UUID] UUIDString];
     NSArray *messageData=@[


### PR DESCRIPTION
尊敬的开发者100apps：
      您好！感谢您对开源社区做出的贡献，您开发的openShare这个用于分享的第三方库功能非常强大，使用也非常方便。但在使用过程中，我们发现了一个bug，就是当OpenShare+Weibo.m中的shareToWeibo:方法时，如果传入的参数msg为空时，项目会崩溃，经过调试，我们发现在OpenShare+Weibo.m中，您只对msg参数是text类型分享，图片类型分享，链接类型分享时做出了判断，并没有考虑到msg参数为nil或者msg参数不满足上述三种情况的情形，所以建议在上面三种分享类型判断的最后加一个else判断。谢谢您的查看！感谢您对开源社区做出的贡献！
![image](https://cloud.githubusercontent.com/assets/16741621/20752172/dc8f8476-b73a-11e6-87fe-49f2588f7bcd.png)


祝好！
ruiwendell