### PR TITLE
修复OpenShare+QQ使用小写十六进制拼接url scheme callback_name 导致的部分版本QQ不兼容的问题

### DIFF
--- a/openshare/OpenShare+QQ.m
+++ b/openshare/OpenShare+QQ.m
@@ -20,7 +20,7 @@ enum
 };
 
 +(void)connectQQWithAppId:(NSString *)appId{
-    [self set:schema Keys:@{@"appid":appId,@"callback_name":[NSString stringWithFormat:@"QQ%08llx",[appId longLongValue]]}];
+    [self set:schema Keys:@{@"appid":appId,@"callback_name":[NSString stringWithFormat:@"QQ%08llX",[appId longLongValue]]}];
 }
 +(BOOL)isQQInstalled{
     return [self canOpen:@"mqqapi://"];


### PR DESCRIPTION
修复OpenShare+QQ使用小写十六进制拼接url scheme callback_name 导致的部分版本QQ不兼容的问题